### PR TITLE
Readme - update dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ complatible with https://github.com/mtodd/geoip
 
 ## Dependencies
 
-This depends on [libmaxminddb](https://github.com/maxmind/libmaxminddb)
+[libmaxminddb](https://github.com/maxmind/libmaxminddb) is bundled with the gem.
+This gem doesn't depend on the system library.
 
 ## Installation
 


### PR DESCRIPTION
https://github.com/dbussink/geoip2_compat/issues/1 continuation.

Current Readme is confusing. This PR clarifies that libmaxminddb is not a system dependency.

Not sure why https://github.com/dbussink/geoip2_compat/pull/4 was closed.